### PR TITLE
feat: write results on remote run

### DIFF
--- a/src/helpers/writeResults.js
+++ b/src/helpers/writeResults.js
@@ -1,0 +1,7 @@
+import fs from 'fs';
+import { NAME_RESULTS_JSON_FILE } from '../constants';
+
+export default ({ outputDirectory, results }) => {
+  const resultsJsonFile = `${outputDirectory}/${NAME_RESULTS_JSON_FILE}`;
+  fs.writeFileSync(resultsJsonFile, JSON.stringify(results));
+};

--- a/src/lighthouseCheck.js
+++ b/src/lighthouseCheck.js
@@ -1,9 +1,11 @@
+import path from 'path';
 import fetchAndWaitForLighthouseAudits from './fetchAndWaitForLighthouseAudits';
 import LighthouseCheckError from './LighthouseCheckError';
 import triggerLighthouse from './triggerLighthouse';
 import localLighthouse from './localLighthouse';
 import postPrComment from './postPrComment';
 import slackNotify from './slackNotify';
+import writeResults from './helpers/writeResults';
 import { NAME, SUCCESS_CODE_GENERIC } from './constants';
 import { ERROR_NO_RESULTS } from './errorCodes';
 import logResults from './logResults';
@@ -36,6 +38,10 @@ export default ({
 }) =>
   new Promise(async (resolve, reject) => {
     try {
+      const outputDirectoryPath = !outputDirectory
+        ? outputDirectory
+        : path.resolve(outputDirectory);
+
       // we either get the result from the API or directly from
       // running a lighthouse audit locally.
       const isLocalAudit = !apiToken;
@@ -143,7 +149,7 @@ export default ({
           awsSecretAccessKey,
           emulatedFormFactor,
           locale,
-          outputDirectory,
+          outputDirectory: outputDirectoryPath,
           throttling,
           throttlingMethod,
           urls,
@@ -166,6 +172,14 @@ export default ({
               sha,
               slackWebhookUrl,
               verbose
+            });
+          }
+
+          // if outputDirectory is specified write the results to disk
+          if (outputDirectoryPath) {
+            writeResults({
+              outputDirectory: outputDirectoryPath,
+              results: lighthouseAudits
             });
           }
 

--- a/src/lighthouseCheck.js
+++ b/src/lighthouseCheck.js
@@ -175,7 +175,7 @@ export default ({
             });
           }
 
-          // if outputDirectory is specified write the results to disk
+          // if output directory is specified write the results to disk
           if (outputDirectoryPath) {
             writeResults({
               outputDirectory: outputDirectoryPath,

--- a/src/localLighthouse.js
+++ b/src/localLighthouse.js
@@ -1,9 +1,8 @@
 import get from 'lodash.get';
-import fs from 'fs';
-import path from 'path';
 import lighthousePersist from '@foo-software/lighthouse-persist';
 import lighthouseDefaultConfig, { throttling } from './lighthouseConfig';
-import { NAME, NAME_RESULTS_JSON_FILE } from './constants';
+import writeResults from './helpers/writeResults';
+import { NAME } from './constants';
 
 const getScoresFromFloat = scores =>
   Object.keys(scores).reduce(
@@ -109,9 +108,6 @@ export default async ({
   verbose
 }) => {
   const auditResults = [];
-  const outputDirectoryPath = !outputDirectory
-    ? outputDirectory
-    : path.resolve(outputDirectory);
 
   let index = 1;
 
@@ -127,7 +123,7 @@ export default async ({
       awsSecretAccessKey,
       emulatedFormFactor,
       locale,
-      outputDirectory: outputDirectoryPath,
+      outputDirectory,
       throttling,
       throttlingMethod,
       url
@@ -138,9 +134,11 @@ export default async ({
   }
 
   // if outputDirectory is specified write the results to disk
-  if (outputDirectoryPath) {
-    const resultsJsonFile = `${outputDirectoryPath}/${NAME_RESULTS_JSON_FILE}`;
-    fs.writeFileSync(resultsJsonFile, JSON.stringify(auditResults));
+  if (outputDirectory) {
+    writeResults({
+      outputDirectory,
+      results: auditResults
+    });
   }
 
   return auditResults;


### PR DESCRIPTION
Support `lighthouse-check/validate-status` when running against the the [Automated Lighthouse Check API](https://www.foo.software/automated-lighthouse-check-how-to-use-the-api/) per issue [#3 reported in Lighthouse Check Orb project](https://github.com/foo-software/lighthouse-check-orb/issues/3).