### PR TITLE
feat: write results on remote run.

### DIFF
--- a/src/lighthouseCheck.js
+++ b/src/lighthouseCheck.js
@@ -94,6 +94,14 @@ export default ({
               verbose
             });
 
+            // if output directory is specified write the results to disk
+            if (outputDirectoryPath) {
+              writeResults({
+                outputDirectory: outputDirectoryPath,
+                results: lighthouseAudits
+              });
+            }
+
             if (slackWebhookUrl) {
               await slackNotify({
                 author,
@@ -172,14 +180,6 @@ export default ({
               sha,
               slackWebhookUrl,
               verbose
-            });
-          }
-
-          // if output directory is specified write the results to disk
-          if (outputDirectoryPath) {
-            writeResults({
-              outputDirectory: outputDirectoryPath,
-              results: lighthouseAudits
             });
           }
 


### PR DESCRIPTION
Fixes change from #7 to write results on remote run. I accidentally added this to the local run in #7 

> Support `lighthouse-check/validate-status` when running against the the [Automated Lighthouse Check API](https://www.foo.software/automated-lighthouse-check-how-to-use-the-api/) per issue [#3 reported in Lighthouse Check Orb project](https://github.com/foo-software/lighthouse-check-orb/issues/3).