### PR TITLE
feat: write results on remote run.

### DIFF
--- a/src/lighthouseCheck.js
+++ b/src/lighthouseCheck.js
@@ -98,7 +98,7 @@ export default ({
             if (outputDirectoryPath) {
               writeResults({
                 outputDirectory: outputDirectoryPath,
-                results: lighthouseAudits
+                results: auditResults
               });
             }
 


### PR DESCRIPTION
🤦‍♂ fixes change from #8 to write results on remote run. I used the wrong variable name in #8. I need an easier way of testing locally.

> Support `lighthouse-check/validate-status` when running against the the [Automated Lighthouse Check API](https://www.foo.software/automated-lighthouse-check-how-to-use-the-api/) per issue [#3 reported in Lighthouse Check Orb project](https://github.com/foo-software/lighthouse-check-orb/issues/3).