### PR TITLE
feat: PR comment badges

### DIFF
--- a/src/helpers/getLighthouseScoreColor.js
+++ b/src/helpers/getLighthouseScoreColor.js
@@ -1,19 +1,19 @@
 // https://developers.google.com/web/tools/lighthouse/v3/scoring
-export default score => {
+export default ({ isHex, score }) => {
   if (typeof score !== 'number') {
-    return '#e0e0e0';
+    return !isHex ? 'lightgrey' : '#e0e0e0';
   }
 
-  let scoreColor = '#0cce6b';
+  let scoreColor = !isHex ? 'green' : '#0cce6b';
 
   // medium range
-  if (score < 75) {
-    scoreColor = '#ffa400';
+  if (score < 90) {
+    scoreColor = !isHex ? 'orange' : '#ffa400';
   }
 
   // bad
-  if (score < 45) {
-    scoreColor = '#f74531';
+  if (score < 50) {
+    scoreColor = !isHex ? 'red' : '#f74531';
   }
 
   return scoreColor;

--- a/src/postPrComment.js
+++ b/src/postPrComment.js
@@ -11,7 +11,7 @@ const getBadge = ({ title, score }) =>
       isHex: false,
       score
     }
-  )}?style=flat-square)`;
+  )}?style=flat-square) `;
 
 export default async ({
   prCommentAccessToken,

--- a/src/postPrComment.js
+++ b/src/postPrComment.js
@@ -1,13 +1,17 @@
 import fetch from './fetch';
+import getLighthouseScoreColor from './helpers/getLighthouseScoreColor';
 import lighthouseAuditTitles from './lighthouseAuditTitles';
 import LighthouseCheckError from './LighthouseCheckError';
 import { ERROR_UNEXPECTED_RESPONSE } from './errorCodes';
 import { NAME } from './constants';
 
-const resultTableHeader = `
-| Audit | Score |
-| ----- | ----- |
-`;
+const getBadge = ({ title, score }) =>
+  `![](https://img.shields.io/badge/${title}-${score}-${getLighthouseScoreColor(
+    {
+      isHex: false,
+      score
+    }
+  )}?style=flat-square)`;
 
 export default async ({
   prCommentAccessToken,
@@ -16,18 +20,18 @@ export default async ({
   verbose
 }) => {
   try {
-    let markdown = `## Lighthouse Audits`;
+    let markdown = `#### Lighthouse`;
 
     results.forEach((result, index) => {
       // the url
       markdown += `\n\n${result.url}`;
 
-      // the table header
-      markdown += `\n\n${resultTableHeader}`;
-
-      // populate the table
+      // badges
       Object.keys(result.scores).forEach(current => {
-        markdown += `| ${lighthouseAuditTitles[current]} | ${result.scores[current]} |\n`;
+        markdown += getBadge({
+          title: lighthouseAuditTitles[current],
+          score: result.scores[current]
+        });
       });
 
       // if we have a URL for the full report

--- a/src/postPrComment.js
+++ b/src/postPrComment.js
@@ -20,23 +20,21 @@ export default async ({
   verbose
 }) => {
   try {
-    let markdown = `#### Lighthouse`;
-
     results.forEach((result, index) => {
-      // the url
-      markdown += `\n\n${result.url}`;
-
       // badges
       Object.keys(result.scores).forEach(current => {
         markdown += getBadge({
-          title: lighthouseAuditTitles[current],
+          title: lighthouseAuditTitles[current].replace(/-/g, '%20'),
           score: result.scores[current]
         });
       });
 
+      // the url
+      markdown += `\n\n${result.url}`;
+
       // if we have a URL for the full report
       if (result.report) {
-        markdown += `\n\n${result.report}`;
+        markdown += `\n\n[Full report](${result.report})`;
       }
 
       // add a horizontal line

--- a/src/slackNotify.js
+++ b/src/slackNotify.js
@@ -55,7 +55,10 @@ export default async ({
                 })
           },
           ...Object.keys(result.scores).map(current => ({
-            color: getLighthouseScoreColor(result.scores[current]),
+            color: getLighthouseScoreColor({
+              isHex: true,
+              score: result.scores[current]
+            }),
             text: `*${lighthouseAuditTitles[current]}*: ${result.scores[current]}`,
             short: true
           }))


### PR DESCRIPTION
# Summary

Display scores in PR comments as badges to replace markdown tables. Addresses one point from issue #5.

Also the following is changed:
- Removes Markdown header `Lighthouse Results` to lessen real estate.
- Updates HTML report link to be linked text.
- Updates scoring color map per newest updates from the [scoring guidelines](https://developers.google.com/web/tools/lighthouse/v3/scoring) (used in Slack notifications and GitHub comment badge colors).