### PR TITLE
feat: support extraHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,14 @@ Below are options for the exported `lighthouseCheck` function or `lighthouse-che
     <td>no</td>
   </tr>
   <tr>
+    <td><code>extraHeaders</code></td>
+    <td>HTTP Header key/value pairs to send in requests. If using the CLI this will need to be stringified, for example: <code>"{\"Cookie\":\"monster=blue\", \"x-men\":\"wolverine\"}"</code></td>
+    <td><code>object</code></td>
+    <td><code>local</code></td>
+    <td><code>undefined</code></td>
+    <td>no</td>
+  </tr>
+  <tr>
     <td><code>emulatedFormFactor</code></td>
     <td>Lighthouse setting only used for local audits. See <a href="src/lighthouseConfig.js">src/lighthouseConfig.js</a> comments for details.</td>
     <td><code>oneOf(['mobile', 'desktop']</code></td>

--- a/src/bin/lighthouse-check.js
+++ b/src/bin/lighthouse-check.js
@@ -45,7 +45,7 @@ const defaultOptions = {
     value: undefined
   },
   extraHeaders: {
-    type: 'string',
+    type: 'object',
     value: undefined
   },
   locale: {

--- a/src/helpers/arguments.js
+++ b/src/helpers/arguments.js
@@ -55,6 +55,12 @@ export const convertOptionsFromArguments = options =>
       value = value.split(',');
     }
 
+    // format object
+    if (option.type === 'object' && value) {
+      value = JSON.parse(value);
+      console.log('value', value);
+    }
+
     if (option.type === 'string' && !value) {
       value = undefined;
     }

--- a/src/helpers/arguments.js
+++ b/src/helpers/arguments.js
@@ -58,7 +58,6 @@ export const convertOptionsFromArguments = options =>
     // format object
     if (option.type === 'object' && value) {
       value = JSON.parse(value);
-      console.log('value', value);
     }
 
     if (option.type === 'string' && !value) {


### PR DESCRIPTION
# Summary

Piggybacks #16 to add support for the `extraHeaders` option.

## Notes

I discovered `extraHeaders` param sent to the Lighthouse NPM module expects an object:
```
 { Error: Protocol error (Network.setExtraHTTPHeaders): Invalid parameters (headers: object expected)
    at Function.fromProtocolMessage (/Users/adam/software/foo/packages/lighthouse-check/node_modules/lighthouse/lighthouse-core/lib/lh-error.js:132:19)
    at callback.resolve.Promise.resolve.then._ (/Users/adam/software/foo/packages/lighthouse-check/node_modules/lighthouse/lighthouse-core/gather/connections/connection.js:123:25)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  protocolMethod: 'Network.setExtraHTTPHeaders',
  protocolError: 'Invalid parameters',
  friendlyMessage: undefined }
```

I was able to test this and confirm the fix by running the CLI locally like so:

```bash
./dist/bin/lighthouse-check.js --urls http://localhost --outputDirectory ./logs --extraHeaders "{\"x-hello-world\":\"foobar\", \"x-hello-fooo\":\"hiii\"}"
```

I have a local app running that simply logs `x-hello-world` header value and I was able to confirm in the HTML reports saved to `./logs` from the command above.