### PR TITLE
fix: better error logging

### DIFF
--- a/src/__snapshots__/triggerLighthouse.test.js.snap
+++ b/src/__snapshots__/triggerLighthouse.test.js.snap
@@ -15,7 +15,7 @@ Object {
       "status": 401,
     },
   ],
-  "error": [Error: All URLs failed to be enqueued. Examine the "data" property of this error for details.],
+  "error": [Error: All URLs failed to be enqueued.],
 }
 `;
 

--- a/src/triggerLighthouse.js
+++ b/src/triggerLighthouse.js
@@ -123,7 +123,7 @@ export default async ({
       const errorMessage =
         errorCode === ERROR_QUEUE_MAX_USED_DAY
           ? queue.results[0].message
-          : 'All URLs failed to be enqueued. Examine the "data" property of this error for details.';
+          : 'All URLs failed to be enqueued.';
 
       if (verbose) {
         console.log(`${NAME}:`, errorMessage);
@@ -149,6 +149,13 @@ export default async ({
 
     if (verbose) {
       console.log(`${NAME}:`, message);
+
+      if (queue.errors) {
+        console.log(
+          `${NAME}: Below is the API response for attempted URLs as an array. Examine the "data" property for error details.`,
+          queue.results
+        );
+      }
     }
 
     // success


### PR DESCRIPTION
# Summary

Adds better error logging when there is an error running Lighthouse tests against the [REST API](https://www.foo.software/automated-lighthouse-check-how-to-use-the-api/).

[Issue #14 in `foo-software/lighthouse-check-action`](https://github.com/foo-software/lighthouse-check-action/issues/14) exposes this.