### PR TITLE
fix: on status checks don't return successfully when scores are zero

### DIFF
--- a/src/validateStatus.js
+++ b/src/validateStatus.js
@@ -6,7 +6,7 @@ import { ERROR_INVALID } from './errorCodes';
 
 const getScoreFailMessage = ({ name, url, minScore, score }) => {
   // if inputs are not specified - assume we shouldn't fail
-  if (!minScore || !score) {
+  if (typeof minScore === 'undefined' || typeof score === 'undefined') {
     return [];
   }
 


### PR DESCRIPTION
## Summary

[Issue #16 in the foo-software/lighthouse-check-action](https://github.com/foo-software/lighthouse-check-action/issues/16) exposes an issue in which [foo-software/lighthouse-check-status-action](https://github.com/foo-software/lighthouse-check-status-action) doesn't correctly throw an error when it should... when a score is `0`. The root of this issue comes from this project in which we're not strictly checking `undefined` values and the `0` integer is passing as falsey.