### PR TITLE
fix: empty string flag values should be ignored.

### DIFF
--- a/src/helpers/arguments.js
+++ b/src/helpers/arguments.js
@@ -44,7 +44,10 @@ export const convertOptionsFromArguments = options => {
       value = JSON.parse(value);
     }
 
-    if (option.type === 'string' && !value) {
+    if (
+      (option.type === 'string' && !value) ||
+      (option.type !== 'boolean' && typeof value === 'boolean')
+    ) {
       value = undefined;
     }
 

--- a/src/helpers/arguments.test.js
+++ b/src/helpers/arguments.test.js
@@ -9,12 +9,14 @@ describe('convertOptionsFromArguments', () => {
     process.argv = [
       '/usr/local/bin/node',
       'lighthouse-check',
+      '--verbose',
       '--ipsum',
       'lorem',
       '--hello',
       'world',
       '--foo',
-      'bar'
+      'bar',
+      '--some-string'
     ];
   });
 
@@ -61,6 +63,24 @@ describe('convertOptionsFromArguments', () => {
       }
     });
     expect(actual).toEqual(expected);
+  });
+
+  it('should treat explicitly defined boolean types as "true" when a value is empty', () => {
+    const actual = convertOptionsFromArguments({
+      verbose: {
+        type: 'boolean'
+      }
+    });
+    expect(actual.verbose).toEqual(true);
+  });
+
+  it('should ignore empty flag values that are not explicitly defined as boolean types', () => {
+    const actual = convertOptionsFromArguments({
+      'some-string': {
+        type: 'string'
+      }
+    });
+    expect(actual['some-string']).toBeUndefined();
   });
 
   it('should create correct types from CLI string argument', () => {


### PR DESCRIPTION
# Summary

Fixes bug introduced in #27. Empty CLI flag values that aren't meant to be `boolean` should be ignored. This change fixes that.