### PR TITLE
fix: empty array flag values should be ignored

### DIFF
--- a/src/helpers/arguments.js
+++ b/src/helpers/arguments.js
@@ -35,7 +35,7 @@ export const convertOptionsFromArguments = options => {
     }
 
     // format array
-    if (option.type === 'array' && value) {
+    if (option.type === 'array' && typeof value === 'string') {
       value = value.split(',');
     }
 

--- a/src/helpers/arguments.test.js
+++ b/src/helpers/arguments.test.js
@@ -16,7 +16,8 @@ describe('convertOptionsFromArguments', () => {
       'world',
       '--foo',
       'bar',
-      '--some-string'
+      '--some-string',
+      '--some-array',
     ];
   });
 
@@ -81,6 +82,15 @@ describe('convertOptionsFromArguments', () => {
       }
     });
     expect(actual['some-string']).toBeUndefined();
+  });
+
+  it('should ignore empty flag values that are explicitly defined as array types', () => {
+    const actual = convertOptionsFromArguments({
+      'some-array': {
+        type: 'array'
+      }
+    });
+    expect(actual['some-array']).toBeUndefined();
   });
 
   it('should create correct types from CLI string argument', () => {


### PR DESCRIPTION
Fixes https://github.com/foo-software/lighthouse-check-orb/issues/8
Similar to https://github.com/foo-software/lighthouse-check/pull/29

Our setup requires that we're able to create urls dynamically. To do this we generate a config file before running the audit where we define `urls`. Because the CircleCI Orb always [passes in `urls`](https://github.com/foo-software/lighthouse-check-orb/blob/06ea6e372bdd8fc36deb8c0503bd10ee1c70aa75/src/commands/audit.yml#L135) as part of the CLI call we were running into a problem when the flags were being parsed as `urls` had no value and was consequently being evaluated as a boolean.