### PR TITLE
Add a rawReport field for output data

### DIFF
--- a/src/fetchAndWaitForLighthouseAudits.js
+++ b/src/fetchAndWaitForLighthouseAudits.js
@@ -74,7 +74,8 @@ export default ({
               performance: current.scorePerformance,
               progressiveWebApp: current.scoreProgressiveWebApp,
               seo: current.scoreSeo
-            }
+            },
+            rawReport: current
           }));
 
           resolve(audits);


### PR DESCRIPTION
This `rawReport` field should add the raw lighthouse data for each url tested. The additional data would be useful for us and hopefully others!

Perhaps there could also be an option to enable or disable this.