### PR TITLE
feat: display device in Slack posts

### DIFF
--- a/src/lighthouseCheck.js
+++ b/src/lighthouseCheck.js
@@ -122,6 +122,7 @@ export default ({
               await slackNotify({
                 author,
                 branch,
+                device: emulatedFormFactor,
                 pr,
                 results: auditResults,
                 sha,
@@ -200,6 +201,7 @@ export default ({
             await slackNotify({
               author,
               branch,
+              device: emulatedFormFactor,
               pr,
               results: lighthouseAudits,
               sha,

--- a/src/slackNotify.js
+++ b/src/slackNotify.js
@@ -6,6 +6,7 @@ import { NAME } from './constants';
 export default async ({
   author,
   branch,
+  device,
   pr: prParam,
   results,
   sha,
@@ -41,7 +42,7 @@ export default async ({
       }
 
       await webhook.send({
-        text: result.url,
+        text: `${result.url} (${device})`,
         attachments: [
           {
             color: '#2091fa',


### PR DESCRIPTION
# Summary

Appends device to Slack post title (`${url} (${device})`).

Fixes #56 