### PR TITLE
feat: surface Lighthouse runtime errors

### DIFF
--- a/src/localLighthouse.js
+++ b/src/localLighthouse.js
@@ -122,6 +122,7 @@ export const localLighthouse = async ({
     localReport,
     report,
     emulatedFormFactor,
+    runtimeError: get(result, 'runtimeError.message'),
     scores
   };
 };

--- a/src/logResults.js
+++ b/src/logResults.js
@@ -44,7 +44,11 @@ export default ({ isGitHubAction, isLocalAudit, isOrb, results }) => {
       Object.values(result.scores)
     ];
     console.log('\n');
-    console.log(table(tableData, tableConfig));
+    if (result.runtimeError) {
+      console.log(`Lighthouse runtime error: ${result.runtimeError}`);
+    } else {
+      console.log(table(tableData, tableConfig));
+    }
     console.log('\n');
   });
 

--- a/src/postPrComment.js
+++ b/src/postPrComment.js
@@ -5,7 +5,7 @@ import LighthouseCheckError from './LighthouseCheckError';
 import { ERROR_UNEXPECTED_RESPONSE } from './errorCodes';
 import { NAME } from './constants';
 
-const getBadge = ({ title, score }) =>
+const getBadge = ({ title, score = 0 }) =>
   `![](https://img.shields.io/badge/${title}-${score}-${getLighthouseScoreColor(
     {
       isHex: false,
@@ -42,6 +42,11 @@ export default async ({
           score: result.scores[current]
         });
       });
+
+      // error
+      if (result.runtimeError) {
+        markdown += `**Lighthouse runtime error**: ${result.runtimeError}\n\n`;
+      }
 
       // table header
       markdown += `\n| Device ${!result.report ? '' : `| Report `}| URL |\n`;

--- a/src/slackNotify.js
+++ b/src/slackNotify.js
@@ -54,6 +54,11 @@ export default async ({
                   footer
                 })
           },
+          ...(result.runtimeError && {
+            color: '#f74531',
+            text: `*Lighthouse runtime error*: ${result.runtimeError}`,
+            short: true
+          }),
           ...Object.keys(result.scores).map(current => ({
             color: getLighthouseScoreColor({
               isHex: true,


### PR DESCRIPTION
# Summary

Catch and surface `runtimeError` from Lighthouse result for more verbose output in the logs, comments and Slack messages.

# Related

- #63 - before this change `null` score values were substituted with `0`, but after - issues like https://github.com/foo-software/lighthouse-check-action/issues/96 were identified due to empty results triggering errors from broken expectations.